### PR TITLE
Dedupe testing lint on CI + fix the lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,4 +44,4 @@ jobs:
       - name: Install Dependencies
         run: npm ci
       - name: Run Tests
-        run: npm test
+        run: npm run test:ember

--- a/tests/integration/components/wizard-guest-test.js
+++ b/tests/integration/components/wizard-guest-test.js
@@ -16,6 +16,10 @@ module('Integration | Component | wizard-guest', function (hooks) {
 
     await render(hbs`<WizardGuest @model={{this.model}}/>`);
 
-    assert.dom().hasText('Create Guest WiFi This will allow guests to use a dedicated WiFi network. Enable Disable The Guest WiFi Network will be disabled. Continue');
+    assert
+      .dom()
+      .hasText(
+        'Create Guest WiFi This will allow guests to use a dedicated WiFi network. Enable Disable The Guest WiFi Network will be disabled. Continue',
+      );
   });
 });

--- a/tests/integration/components/wizard-mode-test.js
+++ b/tests/integration/components/wizard-mode-test.js
@@ -16,6 +16,10 @@ module('Integration | Component | wizard-mode', function (hooks) {
 
     await render(hbs`<WizardMode @model={{this.model}}/>`);
 
-    assert.dom().hasText('Mode Please choose the mode of the device. Configurable Managed The device will be managed by another configurable device. Continue');
+    assert
+      .dom()
+      .hasText(
+        'Mode Please choose the mode of the device. Configurable Managed The device will be managed by another configurable device. Continue',
+      );
   });
 });

--- a/tests/integration/components/wizard-password-test.js
+++ b/tests/integration/components/wizard-password-test.js
@@ -13,8 +13,14 @@ module('Integration | Component | wizard-password', function (hooks) {
     this.set('onChange', () => {});
     this.set('onSubmit', () => {});
 
-    await render(hbs`<WizardPassword @onChange={{this.onChange}} @onSubmit={{this.onSubmit}}/>`);
+    await render(
+      hbs`<WizardPassword @onChange={{this.onChange}} @onSubmit={{this.onSubmit}}/>`,
+    );
 
-    assert.dom().hasText('Password Setup your login credentials Your new password. Please confirm the password. Continue');
+    assert
+      .dom()
+      .hasText(
+        'Password Setup your login credentials Your new password. Please confirm the password. Continue',
+      );
   });
 });

--- a/tests/integration/components/wizard-timezone-test.js
+++ b/tests/integration/components/wizard-timezone-test.js
@@ -12,6 +12,10 @@ module('Integration | Component | wizard-timezone', function (hooks) {
 
     await render(hbs`<WizardTimezone />`);
 
-    assert.dom().hasText('Timezone Please pick the timezone you are in. The default value was automatically detected from your browser settings. Continue');
+    assert
+      .dom()
+      .hasText(
+        'Timezone Please pick the timezone you are in. The default value was automatically detected from your browser settings. Continue',
+      );
   });
 });

--- a/tests/integration/components/wizard-wifi-test.js
+++ b/tests/integration/components/wizard-wifi-test.js
@@ -12,6 +12,10 @@ module('Integration | Component | wizard-wifi', function (hooks) {
 
     await render(hbs`<WizardWifi />`);
 
-    assert.dom().hasText('Create WiFi Network Personalize your WiFi network name and password WiFi Network name (SSID). WiFi Network Password (PSK). Continue');
+    assert
+      .dom()
+      .hasText(
+        'Create WiFi Network Personalize your WiFi network name and password WiFi Network name (SSID). WiFi Network Password (PSK). Continue',
+      );
   });
 });

--- a/tests/unit/controllers/authenticated/device/index-test.js
+++ b/tests/unit/controllers/authenticated/device/index-test.js
@@ -6,7 +6,9 @@ module('Unit | Controller | authenticated/device/index', function (hooks) {
 
   // TODO: Replace this with your real tests.
   test('it exists', function (assert) {
-    let controller = this.owner.lookup('controller:authenticated/devices/index');
+    let controller = this.owner.lookup(
+      'controller:authenticated/devices/index',
+    );
     assert.ok(controller);
   });
 });

--- a/tests/unit/controllers/authenticated/settings/guest-test.js
+++ b/tests/unit/controllers/authenticated/settings/guest-test.js
@@ -1,14 +1,17 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'webui/tests/helpers';
 
-module('Unit | Controller | authenticated/settings/wifi/guest', function (hooks) {
-  setupTest(hooks);
+module(
+  'Unit | Controller | authenticated/settings/wifi/guest',
+  function (hooks) {
+    setupTest(hooks);
 
-  // TODO: Replace this with your real tests.
-  test('it exists', function (assert) {
-    let controller = this.owner.lookup(
-      'controller:authenticated/settings/wifi/guest',
-    );
-    assert.ok(controller);
-  });
-});
+    // TODO: Replace this with your real tests.
+    test('it exists', function (assert) {
+      let controller = this.owner.lookup(
+        'controller:authenticated/settings/wifi/guest',
+      );
+      assert.ok(controller);
+    });
+  },
+);


### PR DESCRIPTION
Currently, the CI runs the linter twice: there is one job dedicated to the lint, then `npm test` relies on concurrently to run both the lint and the Ember tests.

This PR keeps the CI jobs separated for clarity and replaces the "Test" job command with `test:ember`, so the linter runs once. 