### PR TITLE
add lint-to-the-future dashboard

### DIFF
--- a/.github/workflows/lint-to-the-future.yml
+++ b/.github/workflows/lint-to-the-future.yml
@@ -1,0 +1,16 @@
+name: Lint to the Future Dashboard
+
+on:
+  push:
+    branches:
+      - master
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: mansona/lttf-dashboard@v1
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This adds an automatic dashboard for [Lint to the Future](https://github.com/mansona/lint-to-the-future) that will get deployed to the gh-pages branch on this repo. 

For this to be deployed to gh-pages you need to enable this in the settings of the repo.

Here is an example of what the dashboard will look like for the `no-bare-strings` rule: 

![127 0 0 1_8080_rule_lint-to-the-future-ember-template_no-bare-strings](https://github.com/user-attachments/assets/e4474f15-974a-4bc0-aaa8-c7b03638203a)

(Note: this graph only has one point on it because there is no "yesterday" data yet 😉 ) 