### PR TITLE
fix round icons

### DIFF
--- a/app/components/bs-icon-round.hbs
+++ b/app/components/bs-icon-round.hbs
@@ -1,1 +1,1 @@
-<BsIcon @name={{@name}} class="text-white bg-primary h1 px-3 py-3 fixed-width rounded-circle"/>
+<BsIcon @name={{@name}} class="text-white bg-primary p-3 fs-1 lh-1 d-inline-block rounded-circle"/>

--- a/app/components/bs-icon.hbs
+++ b/app/components/bs-icon.hbs
@@ -1,5 +1,5 @@
 {{! template-lint-disable no-invalid-interactive }}
-<span class="align-middle " onclick={{this.click}}>
-    <i class="bi-{{@name}}" ...attributes onclick={{this.click}}/>
+<span class="align-middle " ...attributes onclick={{this.click}}>
+    <i class="bi-{{@name}} d-inline-block lh-1" onclick={{this.click}}/>
     {{yield}}
 </span>

--- a/tests/integration/components/bs-icon-round-test.js
+++ b/tests/integration/components/bs-icon-round-test.js
@@ -10,7 +10,9 @@ module('Integration | Component | bs-icon-round', function (hooks) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
-    await render(hbs`<BsIconRound />`);
+    await render(hbs`<BsIconRound @name="wifi" />`);
+
+    // await this.pauseTest();
 
     assert.dom().hasText('');
 


### PR DESCRIPTION
Note:  I haven't actually tested this PR against any of the icons in the application, I have just used the artificial environment of the integration test (see the commented out `await this.pauseTest()` in the diff)

This change fixes the round icon problem but I don't know that can recommend merging it 🙈 Using icon-fonts is really problematic because styling fonts can become really difficult really quickly (I needed to check with a colleague to find the exact fix for this one). There are also some accessibility concerns. 

An alternative approach would be to swap over to using SVG based icons, either directly or using the sprite https://icons.getbootstrap.com/#usage but I don't exactly know how I would do that with your app
