### PR TITLE
Check i18n job

### DIFF
--- a/.github/workflows/check-i18n.yml
+++ b/.github/workflows/check-i18n.yml
@@ -1,0 +1,33 @@
+name: Check i18n
+
+on:
+  pull_request: {}
+
+jobs:
+  check-i18n:
+    name: "Check i18n"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+      - name: Install Dependencies
+        run: npm ci
+      - run: npm run extract $RUNNER_TEMP
+      - name: Compare source files
+        shell: bash
+        run: |
+          set +e
+          git diff --no-index translations/en-us.json "$RUNNER_TEMP/en-us.json"
+          if [ $? -eq 1 ]; then
+            echo "This PR includes changes in the English messages in the app."
+            echo "Execute 'npm run extract' to update translations/en-us.json"
+            exit 1
+          else
+            echo "Compare ok"
+          fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "ember-concurrency": "^4.0.3",
         "ember-data": "~5.3.9",
         "ember-fetch": "^8.1.2",
-        "ember-formatjs": "^0.1.2",
+        "ember-formatjs": "^0.1.3",
         "ember-intl": "^7.1.8",
         "ember-load-initializers": "^2.1.2",
         "ember-modifier": "^4.2.0",
@@ -18117,15 +18117,14 @@
       }
     },
     "node_modules/ember-formatjs": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ember-formatjs/-/ember-formatjs-0.1.2.tgz",
-      "integrity": "sha512-a5ynfY/y4clAFfOUuR5lS/Qrap0iQ44XhLPIeJI4amHNnmLW30cp9PEAKfCwB9kWZEBp5F7qudMPLXfT1ysKuA==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/ember-formatjs/-/ember-formatjs-0.1.3.tgz",
+      "integrity": "sha512-98ZC5g3GFV2FRKlVC7ZqQX+HAxdQtXUEguiMni9dh9OxoXEGFv2m+zBIp7IlXoAhXj+ajHh9B/xriRosaK1gVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "7.26.5",
         "@formatjs/ts-transformer": "3.13.23",
-        "broccoli-persistent-filter": "3.1.3",
         "broccoli-stew": "3.0.0",
         "calculate-cache-key-for-tree": "2.0.0",
         "ember-cli-babel": "8.2.0",
@@ -18148,168 +18147,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/ember-formatjs/node_modules/async-disk-cache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
-      "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "heimdalljs": "^0.2.3",
-        "istextorbinary": "^2.5.1",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^3.0.0",
-        "rsvp": "^4.8.5",
-        "username-sync": "^1.0.2"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-formatjs/node_modules/broccoli-persistent-filter": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
-      "integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "async-disk-cache": "^2.0.0",
-        "async-promise-queue": "^1.0.3",
-        "broccoli-plugin": "^4.0.3",
-        "fs-tree-diff": "^2.0.0",
-        "hash-for-dep": "^1.5.0",
-        "heimdalljs": "^0.2.1",
-        "heimdalljs-logger": "^0.1.7",
-        "promise-map-series": "^0.2.1",
-        "rimraf": "^3.0.0",
-        "symlink-or-copy": "^1.0.1",
-        "sync-disk-cache": "^2.0.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-formatjs/node_modules/broccoli-plugin": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
-      "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "broccoli-node-api": "^1.7.0",
-        "broccoli-output-wrapper": "^3.2.5",
-        "fs-merger": "^3.2.1",
-        "promise-map-series": "^0.3.0",
-        "quick-temp": "^0.1.8",
-        "rimraf": "^3.0.2",
-        "symlink-or-copy": "^1.3.1"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-formatjs/node_modules/broccoli-plugin/node_modules/promise-map-series": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
-      "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-formatjs/node_modules/editions": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
-      "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "errlop": "^2.0.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/ember-formatjs/node_modules/istextorbinary": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
-      "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "binaryextensions": "^2.1.2",
-        "editions": "^2.2.0",
-        "textextensions": "^2.5.0"
-      },
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://bevry.me/fund"
-      }
-    },
-    "node_modules/ember-formatjs/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/ember-formatjs/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/ember-formatjs/node_modules/rsvp": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-formatjs/node_modules/sync-disk-cache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sync-disk-cache/-/sync-disk-cache-2.1.0.tgz",
-      "integrity": "sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "heimdalljs": "^0.2.6",
-        "mkdirp": "^0.5.0",
-        "rimraf": "^3.0.0",
-        "username-sync": "^1.0.2"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
       }
     },
     "node_modules/ember-functions-as-helper-polyfill": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "ember-concurrency": "^4.0.3",
     "ember-data": "~5.3.9",
     "ember-fetch": "^8.1.2",
-    "ember-formatjs": "^0.1.2",
+    "ember-formatjs": "^0.1.3",
     "ember-intl": "^7.1.8",
     "ember-load-initializers": "^2.1.2",
     "ember-modifier": "^4.2.0",

--- a/scripts/extract.mjs
+++ b/scripts/extract.mjs
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 import { execa } from 'execa';
-
 import { writeFile } from 'node:fs/promises';
+
+let [,,dir] = process.argv;
+dir = dir ?? './translations';
 
 const { stdout } = await execa`npx formatjs extract ./app/**/*.(hbs|js)`;
 
@@ -13,4 +15,4 @@ for (let key in extractedJSON) {
   output[key] = extractedJSON[key].defaultMessage;
 }
 
-await writeFile('./translations/en-us.json', JSON.stringify(output, null, 2));
+await writeFile(`${dir}/en-us.json`, JSON.stringify(output, null, 2));


### PR DESCRIPTION
- update `ember-formatjs` to v0.1.3
- remove the empty `locale` folder that was required by older `ember-formatjs`
- implement the check-i18n job

About the job:

Each time you add new texts to the application, you must run the extract command to update your en-us.json translation file, which becomes the new source of truth. If you forget to regenerate the translation files when the string messages change in the app, you’ll end up with missing translations. With this PR, each time someone opens a Pull Request on the repo, the CI will check the translation file matches the app messages, and the job “Check i18n” will fail if that’s not the case.